### PR TITLE
Display completed challenge count

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -125,6 +125,32 @@ function hideCompleted() {
     }
 }
 
+function updateChallengeCount() {
+    let completed = 0;
+    for (let x = 1; x <= 40; x++) {
+        if (localStorage.getItem("data-ch-2603-" + x) === "yes") {
+            completed++;
+        }
+    }
+    const countText = " (" + completed + " / 40)";
+    
+    // Update main content h1
+    $("h1").each(function() {
+        if ($(this).text().includes("League Challenges")) {
+            let originalTitle = $(this).text().split(" (")[0];
+            $(this).text(originalTitle + countText);
+        }
+    });
+
+    // Update TOC link
+    $("#navigation a").each(function() {
+        if ($(this).text().includes("Mirage Challenges")) {
+            let originalTitle = $(this).text().split(" (")[0];
+            $(this).text(originalTitle + countText);
+        }
+    });
+}
+
 function addCheckboxes() {
     let hideState = localStorage.getItem("data-complete-visibility");
     let i = 0;
@@ -151,6 +177,7 @@ function addCheckboxes() {
             i++;
         }
     })
+    updateChallengeCount();
 }
 
 function clearLocalStorage() {
@@ -177,6 +204,7 @@ $(document).on('click', '.complete', function() {
             $(".li-c").hide();
         }
     }
+    updateChallengeCount();
 });
 GetLeague("league");
 getSidebar();


### PR DESCRIPTION
Introduce `updateChallengeCount()` to display the number of completed challenges in the main title and navigation link. This count is updated when checkboxes are initialized and when a challenge's completion status is toggled.

PS I recommend using TypeScript - it makes development and finding bugs easier, and some reactive UI framework to remove manual DOM manipulations.

<img width="2482" height="716" alt="Screenshot from 2026-03-24 20-37-15" src="https://github.com/user-attachments/assets/a4be93ba-49f7-4b72-a69c-523ccbf4b4c4" />
